### PR TITLE
Fix include/graphics path capitalization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ include $(DEVKITARM)/3ds_rules
 #---------------------------------------------------------------------------------
 TARGET		:=	$(notdir $(CURDIR))
 BUILD		:=	build
-SOURCES		:=	source/include/lua	source source/include source/include/Graphics \
+SOURCES		:=	source/include/lua	source source/include source/include/graphics \
 				source/include/ftp source/include/sf2d source/include/ogg \
 				source/include/lodepng/	source/include/unrar/	source/include/libjpeg \
 				source/include/ttf source/include/khax

--- a/source/luaGraphics.cpp
+++ b/source/luaGraphics.cpp
@@ -33,7 +33,7 @@
 #-----------------------------------------------------------------------------------------------------------------------*/
 #include <3ds.h>
 #include "include/luaplayer.h"
-#include "include/Graphics/Graphics.h"
+#include "include/graphics/Graphics.h"
 
 int cur_screen;
 

--- a/source/luaScreen.cpp
+++ b/source/luaScreen.cpp
@@ -37,7 +37,7 @@
 #include <unistd.h>
 #include <3ds.h>
 #include "include/luaplayer.h"
-#include "include/Graphics/Graphics.h"
+#include "include/graphics/Graphics.h"
 #include "include/ttf/Font.hpp"
 
 #define stringify(str) #str

--- a/source/luaSystem.cpp
+++ b/source/luaSystem.cpp
@@ -36,7 +36,7 @@
 #include <unistd.h>
 #include <3ds.h>
 #include "include/luaplayer.h"
-#include "include/Graphics/Graphics.h"
+#include "include/graphics/Graphics.h"
 #include "include/Archives.h"
 
 #define stringify(str) #str

--- a/source/luaVideo.cpp
+++ b/source/luaVideo.cpp
@@ -39,7 +39,7 @@
 #include <unistd.h>
 #include <3ds.h>
 #include "include/luaplayer.h"
-#include "include/Graphics/Graphics.h"
+#include "include/graphics/Graphics.h"
 #include "include/luaAudio.h"
 #include "include/ogg/ogg.h"
 #include "include/ogg/codec.h"

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -35,7 +35,7 @@
 #include <string.h>
 #include <3ds.h>
 #include "include/luaplayer.h"
-#include "include/Graphics/Graphics.h"
+#include "include/graphics/Graphics.h"
 #include "include/ftp/ftp.h"
 #include "include/khax/khax.h"
 #include "include/luaAudio.h"


### PR DESCRIPTION
The guys who had the idea to make paths case-insensitive on Windows should be made immortal and put into a never-ending fire without any escape so they would suffer the endless pain they inflicted all over the IT world due to their extreme idiocy.

Fixes capital `G` in some include paths as well as Makefile.