### PR TITLE
Fixed spelling of Lua

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <b>Description:</b><br>
 This is the official repository for Lua Player Plus, the first lua interpreter for 3DS made by Rinnegatamante & NaNNi.
 <br><br>
-The interpreter runs under LUA 5.3.1 and is a strict porting of our Lua Player Plus for PSP/PSVITA.
+The interpreter runs under Lua 5.3.1 and is a strict porting of our Lua Player Plus for PSP/PSVITA.
 <br><br>
 Your main script must be in the same directory of 3dsx executable.<br>
 If you're using a Gateway please note that you cannot use Sound Module (it will be replaced by an empty module) and your main script must be in the root of the SD Card.


### PR DESCRIPTION
It's not an acronym. It's Portuguese for moon :+1: 