### PR TITLE
shorten "Title" in RSFs

### DIFF
--- a/cia_workaround.rsf
+++ b/cia_workaround.rsf
@@ -1,5 +1,5 @@
 BasicInfo:
-  Title                   : "Lua Player Plus"
+  Title                   : "LPP-3DS"
   CompanyCode             : "00"
   ProductCode             : "CTR-P-LPPD"
   ContentType             : Application

--- a/gw_workaround.rsf
+++ b/gw_workaround.rsf
@@ -1,5 +1,5 @@
 BasicInfo:
-  Title                   : "Lua Player Plus"
+  Title                   : "LPP-3DS"
   CompanyCode             : "00"
   ProductCode             : "CTR-P-LPPD"
   ContentType             : Application


### PR DESCRIPTION
minor thing at best, but the Title in the exheader can only be 8 characters, so "`Lua Player Plus`" becomes "`Lua Play`".

https://www.3dbrew.org/wiki/NCCH/Extended_Header#System_Control_Info