### PR TITLE
Overhaul HTTP:C

### DIFF
--- a/source/main.cpp
+++ b/source/main.cpp
@@ -66,7 +66,7 @@ int main(int argc, char **argv)
 	acInit();
 	cfguInit();
 	sslcInit(0);
-	httpcInit(0);
+	httpcInit(0x1000);
 	ptmuInit();
 	hidInit();
 	fsInit();


### PR DESCRIPTION
I've fixed up the http networking to work in a more standards compatible manner...

Things fixed:
URL redirection support
Support Transfer-Encoding: chunked and answers without Content-Length header.
Can use GET/POST/HEAD request types.
User specifiable header support
Disables SSL verification (so https:// is _actually_ usable)
Better response status handling 


There might be a few edge cases for status responses that aren't fixed, but I've never seen them actually used before, so this should be good enough.

Three optional arguments have been added to both http functions:
The first is the headers to be included in the request, They should be formatted exactly how they would be presented in the stream, "Name1: Value\nName2: Value" and so on.

The second new argument is the request type, it defaults to GET if no match or not provided, and can be  GET HEAD or POST, and must be in all caps, again the same formatting as it would be in the request. HEAD is just like GET except never returns content. 

The third new argument is the POST data... Sent only when type is POST, it can be up to 4K in length (size is set in httpcInit() if you want to change it, it must be page aligned) Any string content is allowed.

Examples:

`local remoteData = Network.requestString("https://api.titledb.com/v0/","User-Agent: LuaShit/1.0.0\nX-Extra-Header: Extra Data","POST",'{"action":"list"}')

Network.downloadFile("https://api.titledb.com/v0/proxy/00040000001DEA00","/Download.cia","User-Agent: LuaShit/1.0.0")`