### PR TITLE
Added a method to render a text to an Image

### DIFF
--- a/source/include/ttf/Font.cpp
+++ b/source/include/ttf/Font.cpp
@@ -148,7 +148,7 @@ void Font::drawString(int x, int y, const std::string& str, Color color, bool to
 	}
 }
 
-void Font::calcDimensions(const std::string str, int& width, int& height) {
+void Font::calcDimensions(const std::string str, int& width, int& height, int max_width) {
 	if(!isLoaded())
 	{
 		return NULL;
@@ -183,6 +183,11 @@ void Font::calcDimensions(const std::string str, int& width, int& height) {
 		int cheight = bh - by;
 		int oy = ascent + by;
 
+		if(max_width > 0 && sx + cwidth > max_width) {
+			sy += ascent - descent + lineGap;
+			sx = 0;
+		}
+
 		int advance;
 		stbtt_GetCodepointHMetrics(&m_info, str[i], &advance, 0);
 		if(sy + oy + cheight > height) {
@@ -200,7 +205,7 @@ void Font::calcDimensions(const std::string str, int& width, int& height) {
 	}
 }
 
-unsigned char* Font::renderToImage(const std::string& str, Color color, int& width, int& height)
+unsigned char* Font::renderToImage(const std::string& str, Color color, int& width, int& height, int max_width)
 {
 	std::vector<unsigned char> char_raster;
 	int bx, by, bw, bh;
@@ -213,7 +218,7 @@ unsigned char* Font::renderToImage(const std::string& str, Color color, int& wid
 	descent *= m_scale;
 	lineGap *= m_scale;
 
-	this->calcDimensions(str, width, height);
+	this->calcDimensions(str, width, height, max_width);
 	Image image;
 	image.create(width, height, Color(0,0,0,0));
 	sx = 0;
@@ -233,6 +238,11 @@ unsigned char* Font::renderToImage(const std::string& str, Color color, int& wid
 		int char_width = bw - bx;
 		int char_height = bh - by;
 		int oy = ascent + by;
+
+		if(max_width > 0 && sx + char_width > max_width) {
+			sy += ascent - descent + lineGap;
+			sx = 0;
+		}
 
 		char_raster.resize(char_width * char_height);
 

--- a/source/include/ttf/Font.cpp
+++ b/source/include/ttf/Font.cpp
@@ -26,13 +26,13 @@ void* Font::loadFromFile(const std::string& filename)
 {
 	FILE* fp = fopen(filename.c_str(), "r");
 	if (!fp)
-		return false;
+		return NULL;
 	fseek(fp, 0, SEEK_END);
 	unsigned int buffer_size = ftell(fp);
 	unsigned char* buffer = (unsigned char*)malloc(buffer_size);
 	if (!buffer) {
 		fclose(fp);
-		return false;
+		return NULL;
 	}
 	rewind(fp);
 	fread(buffer, 1, buffer_size, fp);
@@ -76,7 +76,7 @@ void Font::setSize(int pixels)
 	m_scale = stbtt_ScaleForPixelHeight(&m_info, pixels);
 }
 
-void Font::drawStringUnicode(int x, int y, const std::wstring& str, Color color, bool top_screen, bool side)
+void Font::drawStringUnicode(int x, int y, const std::wstring& str, Color color, bool top_screen, bool side, int max_width)
 {
 	if(!isLoaded())
 	{
@@ -109,6 +109,11 @@ void Font::drawStringUnicode(int x, int y, const std::wstring& str, Color color,
 		int width = bw - bx;
 		int height = bh - by;
 
+		if(max_width > 0 && sx + width > max_width) {
+			sy += ascent - descent + lineGap;
+			sx = 0;
+		}
+
 		int oy = ascent + by;
 
 		char_raster.resize(width * height);
@@ -139,16 +144,16 @@ void Font::drawStringUnicode(int x, int y, const std::wstring& str, Color color,
 	}
 }
 
-void Font::drawString(int x, int y, const std::string& str, Color color, bool top_screen, bool side)
+void Font::drawString(int x, int y, const std::string& str, Color color, bool top_screen, bool side, int max_width)
 {
 	if(str.length() > 0)
 	{
 		std::wstring unicode_str = std::wstring(str.begin(), str.end());
-		drawStringUnicode(x, y, unicode_str, color, top_screen, side);
+		drawStringUnicode(x, y, unicode_str, color, top_screen, side, max_width);
 	}
 }
 
-void Font::calcDimensions(const std::string str, int& width, int& height, int max_width) {
+void Font::measureText(const std::string str, int& width, int& height, int max_width) {
 	if(!isLoaded())
 	{
 		return NULL;
@@ -205,12 +210,13 @@ void Font::calcDimensions(const std::string str, int& width, int& height, int ma
 	}
 }
 
-unsigned char* Font::renderToImage(const std::string& str, Color color, int& width, int& height, int max_width)
+void Font::drawStringToBuffer(int x, int y, const std::string& str, Color color, unsigned char* buffer, int buffer_width, int buffer_height, int bitsperpixel, int max_width)
 {
 	std::vector<unsigned char> char_raster;
 	int bx, by, bw, bh;
 	int ascent, descent, lineGap;
 	int sx = 0, sy = 0;
+	int width, height;
 
 	stbtt_GetFontVMetrics(&m_info, &ascent, &descent, &lineGap);
 
@@ -218,11 +224,7 @@ unsigned char* Font::renderToImage(const std::string& str, Color color, int& wid
 	descent *= m_scale;
 	lineGap *= m_scale;
 
-	this->calcDimensions(str, width, height, max_width);
-	Image image;
-	image.create(width, height, Color(0,0,0,0));
-	sx = 0;
-	sy = 0;
+	this->measureText(str, width, height, max_width);
 
 	for (unsigned int i = 0; i < str.length(); i++)
 	{
@@ -251,12 +253,53 @@ unsigned char* Font::renderToImage(const std::string& str, Color color, int& wid
 
 		for (int ix = 0; ix < char_width; ix++) {
 			for (int iy = 0; iy < char_height; iy++) {
-				if (char_raster[ix + iy * char_width] != 0)
-					image.putPixel(sx + ix, height - (sy + oy + iy) - 1, Color(color.r, color.g, color.b,
-								char_raster[ix + iy * char_width]));
+				int xpos = x + sx + ix;
+				int ypos = buffer_height - (y + sy + oy + iy) -1;
+				if (char_raster[ix + iy * char_width] != 0 && xpos < buffer_width && ypos < buffer_height) {
+					unsigned int alpha = char_raster[ix + iy * char_width];
+					unsigned int inv_alpha = 255 - alpha;
+					if (bitsperpixel == 24) {
+						unsigned char bg_r = buffer[3 * (xpos + ypos * buffer_width) + 0];
+						unsigned char bg_g = buffer[3 * (xpos + ypos * buffer_width) + 1];
+						unsigned char bg_b = buffer[3 * (xpos + ypos * buffer_width) + 2];
+
+						unsigned char r = (unsigned char)((alpha * color.r + inv_alpha * bg_r) >> 8);
+						unsigned char g = (unsigned char)((alpha * color.g + inv_alpha * bg_g) >> 8);
+						unsigned char b = (unsigned char)((alpha * color.b + inv_alpha * bg_b) >> 8);
+
+						buffer[3 * (xpos + ypos * buffer_width) + 0] = b;
+						buffer[3 * (xpos + ypos * buffer_width) + 1] = g;
+						buffer[3 * (xpos + ypos * buffer_width) + 2] = r;
+					} else {
+						unsigned char bg_r = buffer[4 * (xpos + ypos * buffer_width) + 0];
+						unsigned char bg_g = buffer[4 * (xpos + ypos * buffer_width) + 1];
+						unsigned char bg_b = buffer[4 * (xpos + ypos * buffer_width) + 2];
+						unsigned char bg_a = buffer[4 * (xpos + ypos * buffer_width) + 3];
+
+						unsigned char a;
+						if(alpha == 255 || bg_a == 255) {
+							a = 255;
+						} else {
+							a = alpha + (inv_alpha * bg_a) / 256;
+						}
+						unsigned int r,g,b;
+						if(a == 0) {
+							r = 0;
+							g = 0;
+							b = 0;
+						} else {
+							r = (alpha * color.r + (inv_alpha * bg_a * bg_r) / 256) / a;
+							b = (alpha * color.b + (inv_alpha * bg_a * bg_b) / 256) / a;
+							g = (alpha * color.g + (inv_alpha * bg_a * bg_g) / 256) / a;
+						}
+						buffer[4 * (xpos + ypos * buffer_width) + 0] = b > 255 ? 255 : b;
+						buffer[4 * (xpos + ypos * buffer_width) + 1] = g > 255 ? 255 : g;
+						buffer[4 * (xpos + ypos * buffer_width) + 2] = r > 255 ? 255 : r;
+						buffer[4 * (xpos + ypos * buffer_width) + 3] = a;
+					}
+				}
 			}
 		}
-
 		int advance;
 		stbtt_GetCodepointHMetrics(&m_info, str[i], &advance, 0);
 		sx += advance * m_scale;
@@ -264,45 +307,9 @@ unsigned char* Font::renderToImage(const std::string& str, Color color, int& wid
 		int kerning = stbtt_GetCodepointKernAdvance(&m_info, str[i], str[i + 1]);
 		sx += kerning * m_scale;
 	}
-
-	u8* field = new u8[height * width * 4];
-	std::memcpy(field, image.getPixelsPointer(), height * width * 4);
-	return field;
 }
 
 bool Font::isLoaded()
 {
 	return m_info.data != 0;
-}
-
-float Font::measureText(const std::string& text)
-{	
-	float length = 0.0f;
-	float lineLength = 0.0f;
-	
-	if(isLoaded())
-	{
-		for(unsigned int i = 0; i < text.length(); i++)
-		{
-			if(text[i] == '\n')
-			{
-				if(lineLength > length) {
-					length = lineLength;
-				}
-				
-				lineLength = 0.0f;
-				continue;
-			}
-			
-			int advance = 0;
-			stbtt_GetCodepointHMetrics(&m_info, text[i], &advance, 0);
-			
-			lineLength += advance;
-		}
-		
-		if(lineLength > length)
-			length = lineLength;
-	}
-	
-	return length;
 }

--- a/source/include/ttf/Font.hpp
+++ b/source/include/ttf/Font.hpp
@@ -7,6 +7,7 @@
 #include "Common.hpp"
 #include "Image.hpp"
 #include "stb_truetype.h"
+#include <cstring>
 
 class Font
 {
@@ -38,6 +39,10 @@ public:
 	void drawString(int x, int y, const std::string& str, Color color, bool top_screen = true, bool side = true);
 	
 	void drawStringUnicode(int x, int y, const std::wstring& str, Color color, bool top_screen = true, bool side = true);
+
+	unsigned char* renderToImage(const std::string& str, Color color, int& width, int& height);
+
+	void calcDimensions(const std::string str, int& width, int& height);
 
 private:
 	stbtt_fontinfo m_info;

--- a/source/include/ttf/Font.hpp
+++ b/source/include/ttf/Font.hpp
@@ -30,19 +30,17 @@ public:
 
 	void setScale(float scale);
 	
-	float measureText(const std::string& text);
-	
 	bool isLoaded();
 
 	float getScale() const { return m_scale; }
 	
-	void drawString(int x, int y, const std::string& str, Color color, bool top_screen = true, bool side = true);
+	void drawString(int x, int y, const std::string& str, Color color, bool top_screen = true, bool side = true, int max_width = 0);
 	
-	void drawStringUnicode(int x, int y, const std::wstring& str, Color color, bool top_screen = true, bool side = true);
+	void drawStringUnicode(int x, int y, const std::wstring& str, Color color, bool top_screen = true, bool side = true, int max_width = 0);
 
-	unsigned char* renderToImage(const std::string& str, Color color, int& width, int& height, int max_width);
+	void drawStringToBuffer(int x, int y, const std::string& str, Color color, unsigned char* buffer, int buffer_width, int buffer_height, int bitsperpixel, int max_width = 0);
 
-	void calcDimensions(const std::string str, int& width, int& height, int max_width);
+	void measureText(const std::string str, int& width, int& height, int max_width = 0);
 
 private:
 	stbtt_fontinfo m_info;

--- a/source/include/ttf/Font.hpp
+++ b/source/include/ttf/Font.hpp
@@ -40,9 +40,9 @@ public:
 	
 	void drawStringUnicode(int x, int y, const std::wstring& str, Color color, bool top_screen = true, bool side = true);
 
-	unsigned char* renderToImage(const std::string& str, Color color, int& width, int& height);
+	unsigned char* renderToImage(const std::string& str, Color color, int& width, int& height, int max_width);
 
-	void calcDimensions(const std::string str, int& width, int& height);
+	void calcDimensions(const std::string str, int& width, int& height, int max_width);
 
 private:
 	stbtt_fontinfo m_info;

--- a/source/luaRender.cpp
+++ b/source/luaRender.cpp
@@ -622,7 +622,7 @@ static int lua_loadModel(lua_State *L){
 	#endif
 	luaL_checktype(L, 1, LUA_TTABLE);
 	int len = lua_rawlen(L, 1);
-	char* text = luaL_checkstring(L, 2);
+	char* text = (char*)luaL_checkstring(L, 2);
 	color* ambient = (color*)luaL_checkinteger(L, 3);
 	color* diffuse = (color*)luaL_checkinteger(L, 4);
 	color* specular = (color*)luaL_checkinteger(L, 5);

--- a/source/luaScreen.cpp
+++ b/source/luaScreen.cpp
@@ -787,15 +787,18 @@ static int lua_fsize(lua_State *L) {
 static int lua_calcDimensions(lua_State *L) {
 	int argc = lua_gettop(L);
 #ifndef SKIP_ERROR_HANDLING
-	if (argc != 2) return luaL_error(L, "wrong number of arguments");
+	if (argc != 2 && argc != 3) return luaL_error(L, "wrong number of arguments");
 #endif
 	ttf* font = (ttf*)(luaL_checkinteger(L, 1));
 	char* text = (char*)(luaL_checkstring(L, 2));
+	int max_width = 0;
+	if (argc == 3) 
+		max_width = luaL_checkinteger(L,3);
 #ifndef SKIP_ERROR_HANDLING
 	if (font->magic != 0x4C464E54) return luaL_error(L, "attempt to access wrong memory block type");
 #endif
 	int width, height;
-	font->f.calcDimensions(text, width, height);
+	font->f.calcDimensions(text, width, height, max_width);
 	lua_pushinteger(L, width);
 	lua_pushinteger(L, height);
 	return 2;
@@ -848,11 +851,14 @@ static int lua_fprint(lua_State *L) {
 static int lua_renderToImage(lua_State *L) {
 	int argc = lua_gettop(L);
 #ifndef SKIP_ERROR_HANDLING
-	if (argc != 3) return luaL_error(L, "wrong number of arguments");
+	if (argc != 3 && argc != 4) return luaL_error(L, "wrong number of arguments");
 #endif
 	ttf* font = (ttf*)(luaL_checkinteger(L, 1));
 	char* text = (char*)(luaL_checkstring(L, 2));
 	u32 color = luaL_checkinteger(L,3);
+	int max_width = 0;
+	if (argc == 4)
+		max_width = luaL_checkinteger(L,4);
 #ifndef SKIP_ERROR_HANDLING
 	if (font->magic != 0x4C464E54) return luaL_error(L, "attempt to access wrong memory block type");
 #endif
@@ -860,7 +866,7 @@ static int lua_renderToImage(lua_State *L) {
 	unsigned char* pixels;
 	int width;
 	int height;
-	pixels = font->f.renderToImage(text, Color((color >> 16) & 0xFF, (color >> 8) & 0xFF, (color) & 0xFF), width, height);
+	pixels = font->f.renderToImage(text, Color((color >> 16) & 0xFF, (color >> 8) & 0xFF, (color) & 0xFF), width, height, max_width);
 	bitmap->width = width;
 	bitmap->height = height;
 	bitmap->pixels = pixels;

--- a/source/luaScreen.cpp
+++ b/source/luaScreen.cpp
@@ -784,7 +784,7 @@ static int lua_fsize(lua_State *L) {
     return 0;
 }
 
-static int lua_calcDimensions(lua_State *L) {
+static int lua_measureText(lua_State *L) {
 	int argc = lua_gettop(L);
 #ifndef SKIP_ERROR_HANDLING
 	if (argc != 2 && argc != 3) return luaL_error(L, "wrong number of arguments");
@@ -798,7 +798,7 @@ static int lua_calcDimensions(lua_State *L) {
 	if (font->magic != 0x4C464E54) return luaL_error(L, "attempt to access wrong memory block type");
 #endif
 	int width, height;
-	font->f.calcDimensions(text, width, height, max_width);
+	font->f.measureText(text, width, height, max_width);
 	lua_pushinteger(L, width);
 	lua_pushinteger(L, height);
 	return 2;
@@ -819,64 +819,40 @@ static int lua_unloadFont(lua_State *L) {
 }
 
 static int lua_fprint(lua_State *L) {
-    int argc = lua_gettop(L);
+	int argc = lua_gettop(L);
 	#ifndef SKIP_ERROR_HANDLING
-		if (argc != 6 && argc != 7) return luaL_error(L, "wrong number of arguments");
+		if (argc != 6 && argc != 7 && argc != 8) return luaL_error(L, "wrong number of arguments");
 	#endif
 	ttf* font = (ttf*)(luaL_checkinteger(L, 1));
 	int x = luaL_checkinteger(L, 2);
-    int y = luaL_checkinteger(L, 3);
+	int y = luaL_checkinteger(L, 3);
 	char* text = (char*)(luaL_checkstring(L, 4));
 	u32 color = luaL_checkinteger(L,5);
 	int screen = luaL_checkinteger(L,6);
 	int side=0;
-	if (argc == 7) side = luaL_checkinteger(L,7);
+	if (argc >= 7) side = luaL_checkinteger(L,7);
+	int max_width = 0;
+	if (argc == 8) max_width = luaL_checkinteger(L,8);
 	#ifndef SKIP_ERROR_HANDLING
 		if (font->magic != 0x4C464E54) return luaL_error(L, "attempt to access wrong memory block type");
 		if ((x < 0) || (y < 0)) return luaL_error(L, "out of bounds");
+		if (screen < 0) return luaL_error(L, "wrong SCREEN value");
 		if ((screen == 0) && (x > 400)) return luaL_error(L, "out of framebuffer bounds");
 		if ((screen == 1) && (x > 320)) return luaL_error(L, "out of framebuffer bounds");
 		if ((screen <= 1) && (y > 227)) return luaL_error(L, "out of framebuffer bounds");
-		if (screen != 0 && screen != 1) return luaL_error(L, "wrong SCREEN value");
+		if (screen > 1 && ((Bitmap*)screen)->magic != 0x4C494D47) return luaL_error(L, "attempt to access wrong memory block type");
+		if (screen > 1 && ((Bitmap*)screen)->bitperpixel != 32 && ((Bitmap*)screen)->bitperpixel != 24) return luaL_error(L, "Bitmap has to be 24 or 32 bits per pixel");
 	#endif
-	bool left_side = false;
-	bool top_screen = false;
-	if (screen == 0) top_screen = true;
-	if (side == 0) left_side = true;
-	font->f.drawString(x, y, text, Color((color >> 16) & 0xFF, (color >> 8) & 0xFF, (color) & 0xFF), top_screen, left_side);
-	gfxFlushBuffers();
-    return 0;
-}
-
-static int lua_renderToImage(lua_State *L) {
-	int argc = lua_gettop(L);
-#ifndef SKIP_ERROR_HANDLING
-	if (argc != 3 && argc != 4) return luaL_error(L, "wrong number of arguments");
-#endif
-	ttf* font = (ttf*)(luaL_checkinteger(L, 1));
-	char* text = (char*)(luaL_checkstring(L, 2));
-	u32 color = luaL_checkinteger(L,3);
-	int max_width = 0;
-	if (argc == 4)
-		max_width = luaL_checkinteger(L,4);
-#ifndef SKIP_ERROR_HANDLING
-	if (font->magic != 0x4C464E54) return luaL_error(L, "attempt to access wrong memory block type");
-#endif
-	Bitmap *bitmap = (Bitmap*)malloc(sizeof(Bitmap));
-	unsigned char* pixels;
-	int width;
-	int height;
-	pixels = font->f.renderToImage(text, Color((color >> 16) & 0xFF, (color >> 8) & 0xFF, (color) & 0xFF), width, height, max_width);
-	bitmap->width = width;
-	bitmap->height = height;
-	bitmap->pixels = pixels;
-	bitmap->magic = 0x4C494D47;
-	bitmap->bitperpixel = 32;
-#ifndef SKIP_ERROR_HANDLING
-	if(!bitmap) return luaL_error(L, "Error loading image");
-#endif
-	lua_pushinteger(L, (u32)(bitmap));
-	return 1;
+	if (screen > 1) {
+		Bitmap* canvas = (Bitmap*) screen;
+		font->f.drawStringToBuffer(x, y, text, Color((color >> 16) & 0xFF, (color >> 8) & 0xFF, (color) & 0xFF), canvas->pixels, canvas->width, canvas->height, canvas->bitperpixel, max_width);
+	} else {
+		bool left_side = (bool) 1 - side;
+		bool top_screen = (bool) 1 - screen;
+		font->f.drawString(x, y, text, Color((color >> 16) & 0xFF, (color >> 8) & 0xFF, (color) & 0xFF), top_screen, left_side, max_width);
+		gfxFlushBuffers();
+	}
+	return 0;
 }
 
 //Register our Console Functions
@@ -933,8 +909,7 @@ static const luaL_Reg Font_functions[] = {
   {"print",					lua_fprint}, 
   {"setPixelSizes",			lua_fsize}, 
   {"unload",				lua_unloadFont}, 
-  {"calcDimensions",		lua_calcDimensions},
-  {"renderToImage",			lua_renderToImage},
+  {"measureText",			lua_measureText},
   {0, 0}
 };
 


### PR DESCRIPTION
Hi,

it bothered me, that it was not possible to render text in GPU mode. With this, one can render into a new image, that can be used as a normal image, e.g. converted to a GPU image and drawn into a GPU controlled screen.

     Image_id Font.renderToImage(u32 font, string text, u32 color)

Additionally, one can calculate the dimensions of a given text. This is useful when trying to center a text.

    int, int Font.calcDimensions(u32 font, string text)

I also fixed newline handling in Font.draw.